### PR TITLE
Improvement? - Allow sending to more address types

### DIFF
--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -305,12 +305,18 @@ const SendSetupScreen = ({ navigation, tokensById, balances }: Props) => {
         onPress={() => {
           const addressFormat = SLP.Address.detectAddressFormat(toAddress);
           let hasErrors = false;
-          if (tokenId && addressFormat !== "slpaddr") {
+          if (
+            tokenId &&
+            !["slpaddr", "cashaddr", "legacy"].includes(addressFormat)
+          ) {
             setErrors([
               "Can only send SLP tokens to SimpleLedger addresses.  The to address should begin with `simpleledger:`"
             ]);
             hasErrors = true;
-          } else if (!tokenId && addressFormat !== "cashaddr") {
+          } else if (
+            !tokenId &&
+            !["cashaddr", "legacy"].includes(addressFormat)
+          ) {
             setErrors([
               "Can only send Bitcoin Cash (BCH) to cash addresses, the to address should begin with `bitcoincash:`"
             ]);


### PR DESCRIPTION
# Summary

* Allow sending SLP to `bitcoincash:` and `legacy` addresses
* Allow sending BCH to `legacy` addresses

fixes #46 