### PR TITLE
Bug - crash sending before token update

### DIFF
--- a/ios/badgerMobile/Info.plist
+++ b/ios/badgerMobile/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.0</string>
+	<string>0.7.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badgerMobile",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "homepage": "https://badger.bitcoin.com",
   "repository": {

--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -239,7 +239,7 @@ const SendSetupScreen = ({
     tokenId: null
   };
 
-  let availableAmount = 0;
+  let availableAmount = new BigNumber(0);
   if (tokenId) {
     availableAmount = balances.slpTokens[tokenId];
   } else {
@@ -250,6 +250,10 @@ const SendSetupScreen = ({
     } else {
       availableAmount = availableRaw;
     }
+  }
+
+  if (availableAmount === undefined) {
+    availableAmount = new BigNumber(0);
   }
 
   const coinDecimals = tokenId ? tokensById[tokenId].decimals : 8;


### PR DESCRIPTION
# Summary

When sending a token immediately after sending all of the token, the app could crash on the send setup screen.  
This fixes that.