### PR TITLE
Enhancement - uri scheme flow simplification

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,8 +6,8 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - React (0.59.8):
-    - React/Core (= 0.59.8)
+  - React (0.59.9):
+    - React/Core (= 0.59.9)
   - react-native-camera (2.6.0):
     - React
     - react-native-camera/RCT (= 2.6.0)
@@ -18,62 +18,62 @@ PODS:
     - React
   - react-native-randombytes (3.5.2):
     - React
-  - React/Core (0.59.8):
-    - yoga (= 0.59.8.React)
-  - React/CxxBridge (0.59.8):
+  - React/Core (0.59.9):
+    - yoga (= 0.59.9.React)
+  - React/CxxBridge (0.59.9):
     - Folly (= 2018.10.22.00)
     - React/Core
     - React/cxxreact
     - React/jsiexecutor
-  - React/cxxreact (0.59.8):
+  - React/cxxreact (0.59.9):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
     - React/jsinspector
-  - React/DevSupport (0.59.8):
+  - React/DevSupport (0.59.9):
     - React/Core
     - React/RCTWebSocket
-  - React/fishhook (0.59.8)
-  - React/jsi (0.59.8):
+  - React/fishhook (0.59.9)
+  - React/jsi (0.59.9):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React/jsiexecutor (0.59.8):
+  - React/jsiexecutor (0.59.9):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
     - React/cxxreact
     - React/jsi
-  - React/jsinspector (0.59.8)
-  - React/RCTActionSheet (0.59.8):
+  - React/jsinspector (0.59.9)
+  - React/RCTActionSheet (0.59.9):
     - React/Core
-  - React/RCTAnimation (0.59.8):
+  - React/RCTAnimation (0.59.9):
     - React/Core
-  - React/RCTBlob (0.59.8):
+  - React/RCTBlob (0.59.9):
     - React/Core
-  - React/RCTGeolocation (0.59.8):
+  - React/RCTGeolocation (0.59.9):
     - React/Core
-  - React/RCTImage (0.59.8):
+  - React/RCTImage (0.59.9):
     - React/Core
     - React/RCTNetwork
-  - React/RCTLinkingIOS (0.59.8):
+  - React/RCTLinkingIOS (0.59.9):
     - React/Core
-  - React/RCTNetwork (0.59.8):
+  - React/RCTNetwork (0.59.9):
     - React/Core
-  - React/RCTSettings (0.59.8):
+  - React/RCTSettings (0.59.9):
     - React/Core
-  - React/RCTText (0.59.8):
+  - React/RCTText (0.59.9):
     - React/Core
-  - React/RCTVibration (0.59.8):
+  - React/RCTVibration (0.59.9):
     - React/Core
-  - React/RCTWebSocket (0.59.8):
+  - React/RCTWebSocket (0.59.9):
     - React/Core
     - React/fishhook
     - React/RCTBlob
   - ReactNativePermissions (1.1.1):
     - React
-  - RNCAsyncStorage (1.4.0):
+  - RNCAsyncStorage (1.4.1):
     - React
   - RNGestureHandler (1.1.0):
     - React
@@ -81,7 +81,7 @@ PODS:
     - React
   - RNVectorIcons (6.4.2):
     - React
-  - yoga (0.59.8.React)
+  - yoga (0.59.9.React)
 
 DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -145,16 +145,16 @@ SPEC CHECKSUMS:
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
-  React: 76e6aa2b87d05eb6cccb6926d72685c9a07df152
+  React: a86b92f00edbe1873a63e4a212c29b7a7ad5224f
   react-native-camera: 60e1ec7b259a7779b508712f75671701f23a6b4d
   react-native-randombytes: aa2b5e8bf90a9c0402101c62ed7b145f02940e32
   ReactNativePermissions: b64e084dff6a5cad51587d38c306f09246246384
-  RNCAsyncStorage: 0c3ef98facf3fecf455b518d6f52e10fc964c523
+  RNCAsyncStorage: ee70d057f2576e8060891c98d8babddd46462682
   RNGestureHandler: b65d391f4f570178d657b99a16ec99d09b8656b0
   RNSVG: 9cb6e958c4b6a1f58185ac72a350b148947d6fed
   RNVectorIcons: 6607bd3a30291d0edb56f9bbe7ae411ee2b928b0
-  yoga: 92b2102c3d373d1a790db4ab761d2b0ffc634f64
+  yoga: 03ff42a6f223fb88deeaed60249020d80c3091ee
 
-PODFILE CHECKSUM: c7126102c1114b904c4d5f7101b5dd8ea34d7ea0
+PODFILE CHECKSUM: f2d0eb56d3d1a3aadeb3a9d912ecadac18308043
 
 COCOAPODS: 1.6.1

--- a/ios/badgerMobile/AppDelegate.m
+++ b/ios/badgerMobile/AppDelegate.m
@@ -40,4 +40,11 @@
 #endif
 }
 
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+  sourceApplication:sourceApplication annotation:annotation];
+}
+
 @end

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -80,7 +80,7 @@ const AuthLoadingScreen = ({
     navigation.navigate("SendSetup", {
       symbol: ticker,
       tokenId,
-      uriAddress: formattedAddress,
+      uriAddress: typeof formattedAddress === "string" ? formattedAddress : "",
       uriAmount: amountFormatted
     });
   };

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -39,8 +39,6 @@ const AuthLoadingScreen = ({
   tokensById
 }: Props) => {
   const handleDeepLink = async params => {
-    console.log("IN DEEP LINK");
-    console.log(params);
     const { address, amount, amount1 } = params;
 
     const amounts = Object.entries(params).filter(

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -11,12 +11,6 @@ import { getAccount } from "../data/accounts/actions";
 import { tokensByIdSelector } from "../data/tokens/selectors";
 import { type TokenData } from "../data/tokens/reducer";
 
-// import {
-//   parseAddress,
-//   parseBCHScheme,
-//   getType,
-//   parseSLP
-// } from "../utils/schemeParser-utils";
 import { addressToSlp, addressToCash } from "../utils/account-utils";
 
 const Wrapper = styled(View)`
@@ -45,22 +39,6 @@ const AuthLoadingScreen = ({
   tokensById
 }: Props) => {
   const handleDeepLink = async params => {
-    // const { address } = params;
-
-    // const type = getType(address);
-
-    // console.log(type)
-
-    // if (type === "cashaddr") {
-    //   console.log('cashaddr')
-    //   params = parseBCHScheme(params)
-    //   // params.address = parseAddress(params.address);
-    // }
-    // if (type === "slpaddr") {
-    //   console.log('slpAddr')
-    //   params = parseSLP(params);
-    // }
-
     console.log("IN DEEP LINK");
     console.log(params);
     const { address, amount, amount1 } = params;
@@ -91,34 +69,22 @@ const AuthLoadingScreen = ({
       { tokenId: null, amountFormatted: null }
     );
 
-    console.log("amounts");
-    console.log(amounts);
-
-    // const formattedAmount = amount ? amount : amount1 && amount1.split("-")[0];
-
-    // const tokenId = amount1 && amount1.split("-")[1];
-
     const ticker = tokenId
       ? tokensById[tokenId]
         ? tokensById[tokenId].symbol
         : "---"
       : "BCH";
-    console.log({ tokenId, amount, amount1, amountFormatted });
 
     const formattedAddress = tokenId
       ? await addressToSlp(address)
       : await addressToCash(address);
-    console.log(formattedAddress);
 
-    // compute ticker and tokenId, add amount support for this also.
     navigation.navigate("SendSetup", {
-      uriAddress: formattedAddress,
       symbol: ticker,
       tokenId,
+      uriAddress: formattedAddress,
       uriAmount: amountFormatted
     });
-
-    // navigation.navigate("SendSetup", params);
   };
 
   useEffect(() => {
@@ -127,12 +93,7 @@ const AuthLoadingScreen = ({
     if (mnemonic) {
       // re-generate accounts keypair then go to Main.
       getAccount(mnemonic);
-
-      console.log("AUTH LOADING");
-      console.log(navParams);
-      console.log("!!!!!");
       if (navParams) {
-        console.log("handle deep link");
         handleDeepLink(navParams);
         return;
       }

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -9,8 +9,15 @@ import { T, Spacer } from "../atoms";
 import { getMnemonicSelector } from "../data/accounts/selectors";
 import { getAccount } from "../data/accounts/actions";
 import { tokensByIdSelector } from "../data/tokens/selectors";
+import { type TokenData } from "../data/tokens/reducer";
 
-import { parseAddress, getType, parseSLP } from "../utils/schemeParser-utils";
+// import {
+//   parseAddress,
+//   parseBCHScheme,
+//   getType,
+//   parseSLP
+// } from "../utils/schemeParser-utils";
+import { addressToSlp, addressToCash } from "../utils/account-utils";
 
 const Wrapper = styled(View)`
   justify-content: center;
@@ -25,24 +32,10 @@ const InnerWrapper = styled(View)`
 `;
 
 type Props = {
-  navigation: { navigate: Function },
+  navigation: { navigate: Function, state: { params: any } },
   mnemonic: string,
+  tokensById: { [tokenId: string]: TokenData },
   getAccount: Function
-};
-
-const handleDeepLink = (navigation, params, tokensById) => {
-  const { address } = params;
-
-  const type = getType(address);
-
-  if (type === "cashaddr") {
-    params.address = parseAddress(params.address);
-  }
-  if (type === "slpaddr") {
-    params = parseSLP(params, tokensById);
-  }
-
-  navigation.navigate("SendStack", params);
 };
 
 const AuthLoadingScreen = ({
@@ -51,16 +44,97 @@ const AuthLoadingScreen = ({
   getAccount,
   tokensById
 }: Props) => {
+  const handleDeepLink = async params => {
+    // const { address } = params;
+
+    // const type = getType(address);
+
+    // console.log(type)
+
+    // if (type === "cashaddr") {
+    //   console.log('cashaddr')
+    //   params = parseBCHScheme(params)
+    //   // params.address = parseAddress(params.address);
+    // }
+    // if (type === "slpaddr") {
+    //   console.log('slpAddr')
+    //   params = parseSLP(params);
+    // }
+
+    console.log("IN DEEP LINK");
+    console.log(params);
+    const { address, amount, amount1 } = params;
+
+    const amounts = Object.entries(params).filter(
+      ([key: string, val: string]) => key.startsWith("amount")
+    );
+
+    // Only support sending one token type or BCH at a time
+    const { amountFormatted, tokenId } = amounts.reduce(
+      (acc, curr) => {
+        if (acc.tokenId || acc.amountFormatted) return acc;
+
+        let nextTokenId = null;
+        let nextAmount = null;
+
+        const amountRaw = curr[1];
+        if (amountRaw.includes("-")) {
+          [nextAmount, nextTokenId] = amountRaw.split("-");
+        } else {
+          nextAmount = amountRaw;
+        }
+        return {
+          tokenId: nextTokenId,
+          amountFormatted: nextAmount
+        };
+      },
+      { tokenId: null, amountFormatted: null }
+    );
+
+    console.log("amounts");
+    console.log(amounts);
+
+    // const formattedAmount = amount ? amount : amount1 && amount1.split("-")[0];
+
+    // const tokenId = amount1 && amount1.split("-")[1];
+
+    const ticker = tokenId
+      ? tokensById[tokenId]
+        ? tokensById[tokenId].symbol
+        : "---"
+      : "BCH";
+    console.log({ tokenId, amount, amount1, amountFormatted });
+
+    const formattedAddress = tokenId
+      ? await addressToSlp(address)
+      : await addressToCash(address);
+    console.log(formattedAddress);
+
+    // compute ticker and tokenId, add amount support for this also.
+    navigation.navigate("SendSetup", {
+      uriAddress: formattedAddress,
+      symbol: ticker,
+      tokenId,
+      uriAmount: amountFormatted
+    });
+
+    // navigation.navigate("SendSetup", params);
+  };
+
   useEffect(() => {
-    const params =
-      navigation.state.params !== undefined ? navigation.state.params : "";
-    const hasParams = params !== "";
+    const navParams = navigation.state.params;
 
     if (mnemonic) {
       // re-generate accounts keypair then go to Main.
       getAccount(mnemonic);
-      if (hasParams) {
-        handleDeepLink(navigation, params, tokensById);
+
+      console.log("AUTH LOADING");
+      console.log(navParams);
+      console.log("!!!!!");
+      if (navParams) {
+        console.log("handle deep link");
+        handleDeepLink(navParams);
+        return;
       }
       navigation.navigate("Main");
     } else {

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -39,7 +39,7 @@ const AuthLoadingScreen = ({
   tokensById
 }: Props) => {
   const handleDeepLink = async params => {
-    const { address, amount, amount1 } = params;
+    const { address } = params;
 
     const amounts = Object.entries(params).filter(
       ([key: string, val: string]) => key.startsWith("amount")
@@ -48,7 +48,7 @@ const AuthLoadingScreen = ({
     // Only support sending one token type or BCH at a time
     const { amountFormatted, tokenId } = amounts.reduce(
       (acc, curr) => {
-        if (acc.tokenId || acc.amountFormatted) return acc;
+        if (acc.tokenId && acc.amountFormatted) return acc;
 
         let nextTokenId = null;
         let nextAmount = null;

--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -397,7 +397,15 @@ const SendSetupScreen = ({
 
                   // If there's an amount, set the type to crypto
                   parsedData.amount && setAmountType("crypto");
-                  parsedData.address && setToAddress(parsedData.address);
+                  if (parsedData.address) {
+                    setToAddress(parsedData.address);
+                    const isValidAddress =
+                      SLP.Address.isCashAddress(parsedData.address) ||
+                      SLP.Address.isSLPAddress(parsedData.address);
+                    if (isValidAddress.message) {
+                      setErrors([isValidAddress.message]);
+                    }
+                  }
                   parsedData.amount && setSendAmount(parsedData.amount);
                 }}
                 cameraStyle={{

--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -313,8 +313,10 @@ const SendSetupScreen = ({
     const parameters = parts[1];
     if (parameters) {
       const parameterParts = parameters.split("&");
-      parameterParts.map(param => {
+      parameterParts.forEach(param => {
         const [name, value] = param.split("=");
+        if (amount && uriTokenId) return;
+
         if (name.startsWith("amount")) {
           if (value.includes("-")) {
             const amountSplit = value.split("-");

--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -196,7 +196,6 @@ const SendSetupScreen = ({
 
   const [errors, setErrors] = useState([]);
 
-  // Todo - Handle if send with nothing pre-selected on navigation
   const { symbol, tokenId, uriAddress, uriAmount } = (navigation.state &&
     navigation.state.params) || {
     symbol: null,
@@ -229,15 +228,15 @@ const SendSetupScreen = ({
     }
   }
 
-  if (availableAmount === undefined) {
+  if (!availableAmount) {
     availableAmount = new BigNumber(0);
   }
 
-  const redirectHome = navigation => {
-    return setTimeout(() => {
-      navigation.navigate("Home");
-    }, 3000);
-  };
+  // const redirectHome = navigation => {
+  //   return setTimeout(() => {
+  //     navigation.navigate("Home");
+  //   }, 3000);
+  // };
 
   const coinDecimals =
     tokenId && tokensById[tokenId] ? tokensById[tokenId].decimals : 8;
@@ -272,7 +271,7 @@ const SendSetupScreen = ({
   const sendAmountNumber = parseFloat(sendAmount);
 
   const tokenName =
-    tokensById[tokenId] !== undefined ? tokensById[tokenId].name : "---";
+    tokenId && tokensById[tokenId] ? tokensById[tokenId].name : "---";
   const coinName = !tokenId ? "Bitcoin Cash" : tokenName;
 
   const imageSource = getTokenImage(tokenId);
@@ -322,105 +321,10 @@ const SendSetupScreen = ({
     }
   };
 
-  // const handleDeepLink = ({
-  //   address,
-  //   amount,
-  //   tokenAmount,
-  //   label,
-  //   tokenId,
-  //   symbol
-  // }: DeepLinkParams) => {
-  //   const type = getType(address);
-
-  //   if (sendAmount !== "") {
-  //     return;
-  //   }
-
-  //   if (typeof type !== "string") {
-  //     setErrors(["Invalid Address"]);
-  //     // redirectHome(navigation);
-  //     // return null;
-  //   }
-  //   if (type === "cashaddr") {
-  //     return prefillBCH({ address, amount, label });
-  //   }
-  //   if (type === "slpaddr") {
-  //     prefillSLP({
-  //       address,
-  //       amount,
-  //       tokenAmount,
-  //       label,
-  //       tokenId,
-  //       symbol
-  //     });
-  //   }
-  // };
-
-  // const prefillSLP = ({
-  //   address,
-  //   amount,
-  //   tokenAmount,
-  //   label,
-  //   tokenId,
-  //   symbol
-  // }: DeepLinkParams) => {
-  //   const hasTokenAmount = address && tokenAmount
-
-  //   if (tokenId === undefined) {
-  //     setErrors(["Missing Token Type"]);
-  //     // redirectHome(navigation);
-  //     // return null;
-  //   }
-
-  //   if (hasTokenAmount) {
-  //     try {
-  //       setSendAmountCrypto(tokenAmount);
-  //       // const numericalAmount = parseAmount(tokenAmount);
-  //       setAmountType("crypto");
-  //       setSendAmount(tokenAmount);
-  //     } catch (error) {
-  //       setErrors(["Invalid Amount"]);
-  //       // redirectHome(navigation);
-  //     }
-  //   }
-  //   setToAddress(address);
-  // };
-
-  // const prefillBCH = ({
-  //   address,
-  //   amount,
-  //   tokenAmount,
-  //   label,
-  //   tokenId,
-  //   symbol
-  // }: DeepLinkParams) => {
-  //   const hasAmount = address !== undefined && amount !== undefined;
-
-  //   // never modify state directly...
-  //   // navigation.state.params.symbol = "BCH";
-
-  //   if (hasAmount) {
-  //     try {
-  //       setSendAmountCrypto(amount);
-  //       const numericalAmount = parseAmount(amount);
-  //       setAmountType("crypto");
-  //       setSendAmount(amount);
-  //       setSendAmountFiat(
-  //         fiatRate
-  //           ? (fiatRate * (numericalAmount || 0)).toFixed(
-  //               currencyDecimalMap[fiatCurrency]
-  //             )
-  //           : 0
-  //       );
-  //     } catch (error) {
-  //       setErrors(["invalid amount"]);
-  //     }
-  //   }
-
-  //   setToAddress(address);
-  // };
-
-  const parseQr = (qrData: string, tokensById: any): DeepLinkParams | {} => {
+  const parseQr = (
+    qrData: string,
+    tokensById: { [tokenId: string]: TokenData }
+  ): DeepLinkParams | {} => {
     const address = getAddress(qrData);
 
     const type = getType(address);
@@ -455,37 +359,6 @@ const SendSetupScreen = ({
       );
     }
   }, [sendAmountNumber, amountType, fiatRate]);
-
-  // useEffect(() => {
-
-  //   // Do we need the second part of `&&`?
-  //   const deepLinkParams =
-  //     navigation.state.params && navigation.state.params.address
-  //       ? navigation.state.params
-  //       : {};
-
-  //   const hasDeepLinkParams = typeof deepLinkParams !== "string";
-
-  //   if (hasDeepLinkParams) {
-  //     const {
-  //       address,
-  //       amount,
-  //       tokenAmount,
-  //       label,
-  //       tokenId,
-  //       symbol
-  //     } = deepLinkParams;
-
-  //     handleDeepLink({
-  //       address,
-  //       amount,
-  //       tokenAmount,
-  //       label,
-  //       tokenId,
-  //       symbol
-  //     });
-  //   }
-  // }, []);
 
   const sendAmountFiatFormatted = formatFiatAmount(
     new BigNumber(sendAmountFiat),
@@ -542,7 +415,7 @@ const SendSetupScreen = ({
                   parsedData.tokenAmount &&
                     setSendAmount(parsedData.tokenAmount);
 
-                  // coinName and imageSource are consts, so redirect solves the problem
+                  // coinName and imageSource are type const, so redirect solves the problem
                   // of incorrect names when in bch || slp.
                   // return navigation.navigate({
                   //   routeName: "SendStack",

--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -390,7 +390,6 @@ const SendSetupScreen = ({
                     setErrors([
                       "Sending different coin or token than selected, go to the target coin screen and try again"
                     ]);
-                    setQrOpen(false);
                     return;
                   }
 

--- a/utils/account-utils.js
+++ b/utils/account-utils.js
@@ -35,5 +35,8 @@ const deriveAccount = (
 const addressToSlp = async (address: string) => {
   return await SLP.Address.toSLPAddress(address);
 };
+const addressToCash = async (address: string) => {
+  return await SLP.Address.toCashAddress(address);
+};
 
-export { deriveAccount, addressToSlp, generateMnemonic };
+export { deriveAccount, addressToSlp, addressToCash, generateMnemonic };

--- a/utils/schemeParser-utils.js
+++ b/utils/schemeParser-utils.js
@@ -172,7 +172,7 @@ const getType = (address: string) => {
 
 const checkIsValid = (type: string, address: string) => {
   if (type === "cashaddr") {
-    return SLP.address.isCashAddress(address);
+    return SLP.Address.isCashAddress(address);
   } else if (type === "slpaddr") {
     return SLP.Address.isSLPAddress(address);
   } else {

--- a/utils/schemeParser-utils.js
+++ b/utils/schemeParser-utils.js
@@ -2,12 +2,9 @@
 
 import BigNumber from "bignumber.js";
 import SLPSDK from "slp-sdk";
-import { Address } from "bitbox-sdk";
 import { Utils } from "slpjs";
 
-// const bitboxAddress = new Address();
 const SLP = new SLPSDK();
-// const bitboxAddress = SLP.Address;
 
 const tokenIdRegex = /^([A-Fa-f0-9]{2}){32,32}$/;
 
@@ -33,12 +30,15 @@ const parseAddress = (address: string) => {
 };
 
 // Look into if `amount` is valid here or not
-const parseSLP = (params: {
-  label?: string,
-  amount1?: string,
-  amount?: string,
-  address?: string
-}): {
+const parseSLP = (
+  params: {
+    label?: string,
+    amount1?: string,
+    amount?: string,
+    address?: string
+  },
+  tokensById: any
+): {
   address: string,
   amount: string,
   tokenAmount: string,


### PR DESCRIPTION
# Summary

* Stay on send screen, and give an error if the type is wrong.  
  * I see this similar to going to 'send Doge' from a wallet, and having it automatically move you to something else.  
  * We should add a general scan QR probably on home to take direct to the correct send screen
* Removing all deepLinking references from sendSetupScreen.  Instead pass in the parameters when navigating to the screen, and treat the screen normal thereafter.
* Simplify the `parseQR`
* re-adding some iOS setup code which got lost in the previous PR thrashing
* Updating iOS pods to match the deeplinking depenencies
* Updating flow types throughout