### PR TITLE
Only prefill URI's with single amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,13 @@
 
 - Currency select screen from Menu
 - Change to any base currency to display your BCH balance as.
-  - At first enabling a whistelist of 24 top used currencies
+  - At first enabling a whitelist of 24 top used currencies
 - Number formatting improvements throughout to better match selected currency
 - Improved fee calculations when sending SLP
 
 ### Bug fixes
 
-- Updating bitbox to reduce server load
+- Updating bitbox-sdk to reduce server load
 - Fixed SLP issue sending tokens when user has a large number of SLP related UTXO
 - Fixed bug where new users see negative balance in sending flow
 - Allow sending non fungible tokens without ticker symbols

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -41,39 +41,45 @@ const AuthLoadingScreen = ({
   const handleDeepLink = async params => {
     const { address } = params;
 
+    let amountFormatted = null;
+    let addressFormatted = null;
+    let tokenId = null;
+    let parseError = null;
+
     const amounts = Object.entries(params).filter(
       ([key: string, val: string]) => key.startsWith("amount")
     );
 
-    // Only support sending one token type or BCH at a time
-    const { amountFormatted, tokenId } = amounts.reduce(
-      (acc, curr) => {
-        if (acc.tokenId && acc.amountFormatted) return acc;
+    const amountsFormatted = amounts.map(curr => {
+      const amountRaw = curr[1];
+      let currTokenId = null;
+      let currAmount = null;
 
-        let nextTokenId = null;
-        let nextAmount = null;
+      if (amountRaw.includes("-")) {
+        [currAmount, currTokenId] = amountRaw.split("-");
+      } else {
+        currAmount = amountRaw;
+      }
+      return { tokenId: currTokenId, paramAmount: currAmount };
+    });
 
-        const amountRaw = curr[1];
-        if (amountRaw.includes("-")) {
-          [nextAmount, nextTokenId] = amountRaw.split("-");
-        } else {
-          nextAmount = amountRaw;
-        }
-        return {
-          tokenId: nextTokenId,
-          amountFormatted: nextAmount
-        };
-      },
-      { tokenId: null, amountFormatted: null }
-    );
+    if (amountsFormatted.length > 1) {
+      parseError =
+        "Badger Wallet currently only supports sending one coin at a time.  The URI is requesting multiple coins.";
+    } else if (amountsFormatted.length === 1) {
+      const target = amountsFormatted[0];
+      tokenId = target.tokenId;
+      amountFormatted = target.paramAmount;
+    }
 
-    const formattedAddress = tokenId
+    addressFormatted = tokenId
       ? await addressToSlp(address)
       : await addressToCash(address);
 
     navigation.navigate("SendSetup", {
       tokenId,
-      uriAddress: typeof formattedAddress === "string" ? formattedAddress : "",
+      uriError: parseError,
+      uriAddress: typeof addressFormatted === "string" ? addressFormatted : "",
       uriAmount: amountFormatted
     });
   };

--- a/navigation/AuthLoadingScreen.js
+++ b/navigation/AuthLoadingScreen.js
@@ -12,6 +12,7 @@ import { tokensByIdSelector } from "../data/tokens/selectors";
 import { type TokenData } from "../data/tokens/reducer";
 
 import { addressToSlp, addressToCash } from "../utils/account-utils";
+import { getType } from "../utils/schemeParser-utils";
 
 const Wrapper = styled(View)`
   justify-content: center;
@@ -72,9 +73,12 @@ const AuthLoadingScreen = ({
       amountFormatted = target.paramAmount;
     }
 
-    addressFormatted = tokenId
-      ? await addressToSlp(address)
-      : await addressToCash(address);
+    const type = getType(address);
+
+    addressFormatted =
+      type === "cashaddr"
+        ? await addressToCash(address)
+        : await addressToSlp(address);
 
     navigation.navigate("SendSetup", {
       tokenId,

--- a/screens/RequestScreen.js
+++ b/screens/RequestScreen.js
@@ -337,7 +337,9 @@ const RequestSetupScreen = ({
             />
             {!isShowing && (
               <QROverlay>
-                <T type="accent">Amount Required</T>
+                <T type="accent" center>
+                  Amount Required
+                </T>
               </QROverlay>
             )}
           </QRHolder>


### PR DESCRIPTION
# Summary

* Only pre-fill amounts if the URI is for a single coin/token
* Show a simple error when the URI has multiple types
* Center text on request screen