### PR TITLE
Improvement - history 145 245

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This project use `react-native`. Please refer to the React Native documentation 
 > pod install
 > cd ..
 > yarn run ios
+> yarn start
 ```
 
 To run on a specific device, such as required for taking screenshots for the store (6.5" & 5.5"). Xs Max and iPhone 8 plus are good store screenshot phones.

--- a/components/TransactionRow/TransactionRow.js
+++ b/components/TransactionRow/TransactionRow.js
@@ -19,10 +19,10 @@ const Row = styled(View)`
   ${props =>
     props.type === "send"
       ? css`
-          background-color: ${props => props.theme.danger700};
+          background-color: ${props => props.theme.accent900};
         `
       : css`
-          background-color: ${props => props.theme.success700};
+          background-color: ${props => props.theme.primary900};
         `}
 `;
 

--- a/themes/spaceBadger.js
+++ b/themes/spaceBadger.js
@@ -16,8 +16,9 @@ type Theme = {
 const spaceBadger: Theme = {
   primary500: "#0AC18E",
   primary700: "#11a87e",
+  primary900: "#edfaf6",
   accent500: "#F5871A",
-  accent900: "#FEF5EC",
+  accent900: "#faf6ed",
   fg100: "#111724",
   fg200: "#454c53",
   fg300: "#7d7d7d",


### PR DESCRIPTION
# Not ready  - Do Not Merge

## Goals

- [ ] Show BCH sent to the 245 path in the BCH history
- [ ] vice-versa for SLP tokens sent to 145 path.
- [ ] general improvements to the history display

## Issues
fixes #134 
fixes #69 