### PR TITLE
Bug - Refresh UTXO before BIP70

### DIFF
--- a/data/utxos/selectors.js
+++ b/data/utxos/selectors.js
@@ -23,4 +23,13 @@ const doneInitialLoadSelector = createSelector(
   }
 );
 
-export { utxosSelector, utxosByAccountSelector, doneInitialLoadSelector };
+const isUpdatingUTXO = (state: FullState) => {
+  return state.utxos.updating;
+};
+
+export {
+  utxosSelector,
+  utxosByAccountSelector,
+  doneInitialLoadSelector,
+  isUpdatingUTXO
+};

--- a/screens/Bip70ConfirmScreen.js
+++ b/screens/Bip70ConfirmScreen.js
@@ -20,12 +20,18 @@ import { type UTXO } from "../data/utxos/reducer";
 import { type ECPair, type Account } from "../data/accounts/reducer";
 
 import { updateTokensMeta } from "../data/tokens/actions";
+import { updateUtxos } from "../data/utxos/actions";
 
 import {
   getKeypairSelector,
-  activeAccountSelector
+  activeAccountSelector,
+  getAddressSelector,
+  getAddressSlpSelector
 } from "../data/accounts/selectors";
-import { utxosByAccountSelector } from "../data/utxos/selectors";
+import {
+  utxosByAccountSelector,
+  isUpdatingUTXO
+} from "../data/utxos/selectors";
 import { spotPricesSelector, currencySelector } from "../data/prices/selectors";
 
 import {
@@ -74,10 +80,14 @@ type Props = {
   tokensById: { [tokenId: string]: TokenData },
   utxos: UTXO[],
   keypair: { bch: ECPair, slp: ECPair },
+  utxoUpdating: boolean,
   spotPrices: any,
   fiatCurrency: CurrencyCode,
   activeAccount: Account,
+  addressSlp: string,
+  address: string,
   updateTokensMeta: Function,
+  updateUtxos: Function,
   navigation: {
     navigate: Function,
     goBack: Function,
@@ -93,11 +103,15 @@ type Props = {
 const Bip70ConfirmScreen = ({
   navigation,
   tokensById,
+  address,
+  addressSlp,
   activeAccount,
   utxos,
   fiatCurrency,
   keypair,
   spotPrices,
+  utxoUpdating,
+  updateUtxos,
   updateTokensMeta
 }: Props) => {
   // Props / state variables
@@ -143,6 +157,11 @@ const Bip70ConfirmScreen = ({
     }
     return { name: null, symbol: null, decimals: null };
   }, [paymentDetails, tokensById]);
+
+  // update UTXOs on load
+  useEffect(() => {
+    updateUtxos(address, addressSlp);
+  }, [address, addressSlp, updateUtxos]);
 
   // Fetch token Metadata if it is unknown
   useEffect(() => {
@@ -470,22 +489,28 @@ const Bip70ConfirmScreen = ({
 const mapStateToProps = state => {
   const tokensById = tokensByIdSelector(state);
   const activeAccount = activeAccountSelector(state);
+  const address = getAddressSelector(state);
+  const addressSlp = getAddressSlpSelector(state);
   const utxos = utxosByAccountSelector(state, activeAccount.address);
   const keypair = getKeypairSelector(state);
   const spotPrices = spotPricesSelector(state);
   const fiatCurrency = currencySelector(state);
+  const utxoUpdating = isUpdatingUTXO(state);
 
   return {
     activeAccount,
+    address,
+    addressSlp,
     keypair,
     spotPrices,
     fiatCurrency,
     tokensById,
+    utxoUpdating,
     utxos
   };
 };
 
-const mapDispatchToProps = { updateTokensMeta };
+const mapDispatchToProps = { updateTokensMeta, updateUtxos };
 
 export default connect(
   mapStateToProps,

--- a/utils/bip70-utils.js
+++ b/utils/bip70-utils.js
@@ -57,6 +57,16 @@ const postAsArrayBuffer = (
     req.responseType = "arraybuffer";
     req.onload = function(event) {
       let resp = req.response;
+
+      if (req.status === 400 || req.status === 404 || req.status === 500) {
+        reject(
+          new Error(
+            `${req.status} Error processing payment, please check with the merchant and try again.`
+          )
+        );
+        return;
+      }
+
       if (resp) {
         accept(resp);
       }

--- a/utils/transaction-utils.js
+++ b/utils/transaction-utils.js
@@ -406,7 +406,7 @@ const signAndPublishSlpTransaction = async (
 };
 
 const sweep = async (
-  wif: string,
+  wif: ?string,
   toAddr: string,
   balanceOnly: boolean = false
 ) => {
@@ -443,8 +443,7 @@ const sweep = async (
     const utxos: UTXO[] = u.utxos;
 
     // Prepare to generate a transaction to sweep funds.
-
-    const transactionBuilder: TransactionBuilder = new SLP.TransactionBuilder(
+    const transactionBuilder = new SLP.TransactionBuilder(
       SLP.Address.detectAddressNetwork(fromAddr)
     );
     let originalAmount: number = 0;


### PR DESCRIPTION
# Issue

When sending multiple BIP70 payments within 30 seconds, the UTXO may not be refreshed, and Badger tries to re-spend utxo.

## Fix
* Refresh UTXO when BIP70 screen mounts so they are more likely to be the current state.
* Improve error messaging in BIP70 flow