### PR TITLE
Restrict BCH to cashaddr and slp to simpleledger addresses

### DIFF
--- a/screens/SendSetupScreen.js
+++ b/screens/SendSetupScreen.js
@@ -339,14 +339,15 @@ const SendSetupScreen = ({
     }
 
     let hasErrors = false;
-    if (tokenId && !["slpaddr", "cashaddr", "legacy"].includes(addressFormat)) {
+
+    if (tokenId && !["slpaddr"].includes(addressFormat)) {
       setErrors([
-        "Can only send SLP tokens to SimpleLedger addresses.  The to address should begin with `simpleledger:`"
+        "Can only send SLP tokens to Simpleledger addresses.  The to address should begin with 'simpleledger:'"
       ]);
       hasErrors = true;
-    } else if (!tokenId && !["cashaddr", "legacy"].includes(addressFormat)) {
+    } else if (!tokenId && !["cashaddr"].includes(addressFormat)) {
       setErrors([
-        "Can only send Bitcoin Cash (BCH) to cash addresses, the to address should begin with `bitcoincash:`"
+        "Can only send Bitcoin Cash (BCH) to cash addresses, the to address should begin with 'bitcoincash:'"
       ]);
       hasErrors = true;
     }


### PR DESCRIPTION
Send BCH to cashaddresses only
Send SLP to simpleledger addresses only.

fixes #191 