### PR TITLE
Bug - history speed up and UI hanging

### DIFF
--- a/data/transactions/actions.js
+++ b/data/transactions/actions.js
@@ -41,25 +41,10 @@ const updateTransactions = (address: string, addressSlp: string) => {
 
     const currentState = getState();
 
-    // Short circuit if already processing.
-    if (currentState.transactions.updating) {
-      console.log("SHORT CIRCUIT UPDATE");
-      return;
-    }
-    // if(currentState.up)
-
-    console.log("current state");
-    console.log(currentState);
-
-    console.log("-$_$-$-$    1 - fast");
-
     dispatch(getTransactionsStart());
 
-    // currentState = getState();
     const latestBlock = transactionsLatestBlockSelector(currentState);
     const allTxIds = new Set(transactionsSelector(currentState).allIds);
-
-    console.log("-$_$-$-$    2 - fast");
 
     const transactionsBCH = getHistoricalBchTransactions(
       address,
@@ -67,139 +52,123 @@ const updateTransactions = (address: string, addressSlp: string) => {
       latestBlock
     );
 
-    console.log("-$_$-$-$    3 - fast");
-
     const transactionsSlp = getHistoricalSlpTransactions(
       address,
       addressSlp,
       latestBlock
     );
 
-    console.log("-$_$-$-$    4 - fast");
-
     const [bchHistory, slpHistory] = await Promise.all([
       transactionsBCH,
       transactionsSlp
     ]);
 
-    console.log("-$_$-$-$    5 - medium");
-    console.log(bchHistory.length);
+    const formattedTransactionsBCH: Transaction[] = [];
 
-    const formattedTransactionsBCH: Transaction[] = bchHistory
-      .map(tx => {
-        const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
-        const hash = tx.tx.h;
-
-        // Unconfirmed and already parsed
-        if (block === 0 && allTxIds.has(hash)) {
-          return null;
-        }
-
-        const fromAddressesAll = tx.in
-          .filter(input => input.e && input.e.a)
-          .map(input => SLP.Address.toCashAddress(input.e.a));
-
-        const fromAddresses = [...new Set(fromAddressesAll)];
-
-        let fromAddress = fromAddresses.length === 1 ? fromAddresses[0] : null;
-
-        // Prefer BCH address over SLP address
-        if (!fromAddress) {
-          if (fromAddresses.includes(address)) {
-            fromAddress = address;
-          } else if (fromAddresses.includes(addressSlp)) {
-            fromAddress = addressSlp;
-          }
-        }
-
-        const toAddressesAll = tx.out
-          .filter(output => output.e && output.e.a)
-          .map(output => SLP.Address.toCashAddress(output.e.a));
-
-        const toAddresses = [...new Set(toAddressesAll)];
-
-        // If one to address, use that.
-        let toAddress = toAddresses.length === 1 ? toAddresses[0] : null;
-
-        // Detect if it's from this wallet
-        // const fromUser = fromAddresses.reduce((acc, curr) => {
-        //   if (acc) return acc;
-        //   return [address, addressSlp].includes(curr);
-        // }, false);
-
-        const fromUser =
-          fromAddresses.includes(address) || fromAddresses.includes(addressSlp);
-
-        // if from us, search for an external address
-        if (fromUser) {
-          toAddress = toAddresses.reduce((acc, curr) => {
-            if (acc) return acc;
-            return [address, addressSlp].includes(curr) ? null : curr;
-          }, null);
-        }
-
-        if (!toAddress) {
-          // else search for one of our addresses
-          toAddress = toAddresses.includes(address)
-            ? address
-            : toAddresses.includes(addressSlp) && addressSlp;
-        }
-
-        const valueAddresses = toAddresses.filter(target => {
-          return fromUser
-            ? ![address, addressSlp].includes(target)
-            : [address, addressSlp].includes(target);
-        });
-
-        // Determine value
-        let value = 0;
-        if (toAddress && fromAddress !== toAddress) {
-          value = tx.out.reduce((accumulator, currentTx) => {
-            if (
-              currentTx.e &&
-              currentTx.e.v &&
-              valueAddresses.includes(SLP.Address.toCashAddress(currentTx.e.a))
-            ) {
-              accumulator += currentTx.e.v;
-            }
-            return accumulator;
-          }, 0);
-        }
-
-        return {
-          hash,
-          txParams: {
-            from: fromAddress,
-            to: toAddress,
-            fromAddresses,
-            toAddresses,
-            valueBch: value
-          },
-          time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
-          block,
-          status: "confirmed",
-          networkId: "mainnet"
-        };
-      })
-      .filter(Boolean);
-
-    console.log("-$_$-$-$    5.5 - SLOW");
-    console.log(slpHistory.length);
-
-    console.time("slp");
-
-    // const slpHistoryChunks = _.chunk(slpHistory, 2);
-    const formattedTransactionsSLP = [];
-
-    for (let tx of slpHistory) {
-      // const formattedTx = [historyItem]
-      //   .map(tx => {
+    for (let tx of bchHistory) {
       const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
       const hash = tx.tx.h;
 
       // Unconfirmed and already parsed
       if (block === 0 && allTxIds.has(hash)) {
-        return null;
+        continue;
+      }
+
+      const fromAddressesAll = tx.in
+        .filter(input => input.e && input.e.a)
+        .map(input => SLP.Address.toCashAddress(input.e.a));
+
+      const fromAddresses = [...new Set(fromAddressesAll)];
+
+      let fromAddress = fromAddresses.length === 1 ? fromAddresses[0] : null;
+
+      // Prefer BCH address over SLP address
+      if (!fromAddress) {
+        if (fromAddresses.includes(address)) {
+          fromAddress = address;
+        } else if (fromAddresses.includes(addressSlp)) {
+          fromAddress = addressSlp;
+        }
+      }
+
+      const toAddressesAll = tx.out
+        .filter(output => output.e && output.e.a)
+        .map(output => SLP.Address.toCashAddress(output.e.a));
+
+      const toAddresses = [...new Set(toAddressesAll)];
+
+      // If one to address, use that.
+      let toAddress = toAddresses.length === 1 ? toAddresses[0] : null;
+
+      // Detect if it's from this wallet
+      const fromUser =
+        fromAddresses.includes(address) || fromAddresses.includes(addressSlp);
+
+      // if from us, search for an external address
+      if (fromUser) {
+        toAddress = toAddresses.reduce((acc, curr) => {
+          if (acc) return acc;
+          return [address, addressSlp].includes(curr) ? null : curr;
+        }, null);
+      }
+
+      if (!toAddress) {
+        // else search for one of our addresses
+        toAddress = toAddresses.includes(address)
+          ? address
+          : toAddresses.includes(addressSlp) && addressSlp;
+      }
+
+      const valueAddresses = toAddresses.filter(target => {
+        return fromUser
+          ? ![address, addressSlp].includes(target)
+          : [address, addressSlp].includes(target);
+      });
+
+      // Determine value
+      let value = 0;
+      if (toAddress && fromAddress !== toAddress) {
+        value = tx.out.reduce((accumulator, currentTx) => {
+          if (
+            currentTx.e &&
+            currentTx.e.v &&
+            valueAddresses.includes(SLP.Address.toCashAddress(currentTx.e.a))
+          ) {
+            accumulator += currentTx.e.v;
+          }
+          return accumulator;
+        }, 0);
+      }
+
+      const formattedTx = {
+        hash,
+        txParams: {
+          from: fromAddress,
+          to: toAddress,
+          fromAddresses,
+          toAddresses,
+          valueBch: value
+        },
+        time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
+        block,
+        status: "confirmed",
+        networkId: "mainnet"
+      };
+
+      formattedTx && formattedTransactionsBCH.push(formattedTx);
+
+      // Allow the UI to render after each item computes.
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    const formattedTransactionsSLP: Transaction[] = [];
+    for (let tx of slpHistory) {
+      const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
+      const hash = tx.tx.h;
+
+      // Unconfirmed and already parsed
+      if (block === 0 && allTxIds.has(hash)) {
+        continue;
       }
 
       const { slp } = tx;
@@ -328,171 +297,14 @@ const updateTransactions = (address: string, addressSlp: string) => {
         time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
         block,
         status: "confirmed",
-        network: "mainnet"
+        networkId: "mainnet"
       };
 
-      // .filter(Boolean);
-
-      console.log("render release?");
       formattedTx && formattedTransactionsSLP.push(formattedTx);
 
       // Allow the UI to render after each item computes.
       await new Promise(resolve => setTimeout(resolve, 0));
-      console.log("render done?");
     }
-
-    console.log("done?");
-    console.log(formattedTransactionsSLP.length);
-
-    // const formattedTransactionsSLP: Transaction[] = slpHistory
-    //   .map(tx => {
-    //     const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
-    //     const hash = tx.tx.h;
-
-    //     // Unconfirmed and already parsed
-    //     if (block === 0 && allTxIds.has(hash)) {
-    //       return null;
-    //     }
-
-    //     const { slp } = tx;
-    //     const inputs = tx.in;
-
-    //     const { outputs, tokenIdHex, transactionType, decimals } = slp.detail;
-
-    //     // All from addresses in cashaddr format
-    //     const fromAddresses = inputs
-    //       .filter(input => input.e && input.e.a)
-    //       .map(input => {
-    //         const addr = SLP.Address.toCashAddress(input.e.a);
-    //         return addr;
-    //       });
-
-    //     // All to addresses in cashaddr format
-    //     const toAddressesSLP = outputs
-    //       .filter(output => output.address)
-    //       .map(output => {
-    //         const addr = SLP.Address.toCashAddress(output.address);
-    //         return addr;
-    //       });
-
-    //     const toAddressesBCHAll = tx.out
-    //       .filter(output => output.e && output.e.a)
-    //       .map(output => SLP.Address.toCashAddress(output.e.a));
-
-    //     const toAddressesBCH = [...new Set(toAddressesBCHAll)];
-
-    //     const toAddresses = [...toAddressesSLP, ...toAddressesBCH];
-
-    //     // Detect if it's from this wallet
-    //     let fromUser = fromAddresses.reduce((acc, curr) => {
-    //       if (acc) return acc;
-    //       return [address, addressSlp].includes(curr);
-    //     }, false);
-
-    //     let fromAddress = fromAddresses.length === 1 ? fromAddresses[0] : null;
-
-    //     // If sending SLP, show from SLP address over the BCH address
-    //     if (!fromAddress) {
-    //       if (fromAddresses.includes(addressSlp)) {
-    //         fromAddress = addressSlp;
-    //       } else if (fromAddresses.includes(address)) {
-    //         fromAddress = address;
-    //       }
-    //     }
-
-    //     let toAddress = null;
-
-    //     // if from us, search for an external address
-    //     if (fromUser) {
-    //       toAddress = toAddresses.reduce((acc, curr) => {
-    //         if (acc) return acc;
-    //         return [address, addressSlp].includes(curr) ? null : curr;
-    //       }, null);
-    //     } else {
-    //       // else search for one of our addresses
-    //       toAddress = toAddresses.includes(addressSlp)
-    //         ? addressSlp
-    //         : toAddresses.includes(address) && address;
-    //     }
-
-    //     // Else from and to us?
-    //     if (fromUser && !toAddress) {
-    //       // Change to false so these appear as received
-    //       fromUser = false;
-    //       toAddress = toAddresses.includes(addressSlp)
-    //         ? addressSlp
-    //         : toAddresses.includes(address) && address;
-    //     }
-
-    //     // Determine SLP value
-    //     let value = new BigNumber(0);
-    //     if (toAddress && fromAddress !== toAddress) {
-    //       value = outputs.reduce((accumulator, currentValue) => {
-    //         if (currentValue.address && currentValue.amount) {
-    //           const outputAddress = SLP.Address.toCashAddress(
-    //             currentValue.address
-    //           );
-    //           if (outputAddress === toAddress) {
-    //             accumulator = accumulator.plus(
-    //               new BigNumber(currentValue.amount)
-    //             );
-    //           }
-    //         }
-    //         return accumulator;
-    //       }, new BigNumber(0));
-    //     }
-
-    //     const valueAddresses = fromUser
-    //       ? toAddresses.filter(
-    //           target => ![address, addressSlp].includes(target)
-    //         )
-    //       : toAddresses.filter(target =>
-    //           [address, addressSlp].includes(target)
-    //         );
-
-    //     // Determine BCH value
-    //     let bchValue = 0;
-    //     if (toAddress && fromAddress !== toAddress) {
-    //       bchValue = tx.out.reduce((accumulator, currentTx) => {
-    //         if (
-    //           currentTx.e &&
-    //           currentTx.e.v &&
-    //           valueAddresses.includes(
-    //             SLP.Address.toCashAddress(currentTx.e.a)
-    //           ) &&
-    //           currentTx.e.v !== 546
-    //         ) {
-    //           accumulator += currentTx.e.v;
-    //         }
-    //         return accumulator;
-    //       }, 0);
-    //     }
-
-    //     return {
-    //       hash,
-    //       txParams: {
-    //         from: fromAddress,
-    //         to: toAddress,
-    //         fromAddresses,
-    //         toAddresses,
-    //         valueBch: bchValue,
-    //         transactionType,
-    //         sendTokenData: {
-    //           tokenProtocol: "slp",
-    //           tokenId: tokenIdHex,
-    //           valueToken: value.toFixed(decimals)
-    //         }
-    //       },
-    //       time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
-    //       block,
-    //       status: "confirmed",
-    //       network: "mainnet"
-    //     };
-    //   })
-    //   .filter(Boolean);
-
-    console.log("-$_$-$-$    6 - SLOW - DONE");
-    console.timeEnd("slp");
 
     const formattedTransactionsNew = [
       ...formattedTransactionsBCH,

--- a/data/transactions/actions.js
+++ b/data/transactions/actions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import BigNumber from "bignumber.js";
-import _ from "lodash";
 
 import {
   GET_TRANSACTIONS_START,

--- a/data/transactions/actions.js
+++ b/data/transactions/actions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import BigNumber from "bignumber.js";
+import _ from "lodash";
 
 import {
   GET_TRANSACTIONS_START,
@@ -38,11 +39,27 @@ const updateTransactions = (address: string, addressSlp: string) => {
   return async (dispatch: Function, getState: Function) => {
     if (!address || !addressSlp) return;
 
+    const currentState = getState();
+
+    // Short circuit if already processing.
+    if (currentState.transactions.updating) {
+      console.log("SHORT CIRCUIT UPDATE");
+      return;
+    }
+    // if(currentState.up)
+
+    console.log("current state");
+    console.log(currentState);
+
+    console.log("-$_$-$-$    1 - fast");
+
     dispatch(getTransactionsStart());
 
-    const currentState = getState();
+    // currentState = getState();
     const latestBlock = transactionsLatestBlockSelector(currentState);
     const allTxIds = new Set(transactionsSelector(currentState).allIds);
+
+    console.log("-$_$-$-$    2 - fast");
 
     const transactionsBCH = getHistoricalBchTransactions(
       address,
@@ -50,16 +67,23 @@ const updateTransactions = (address: string, addressSlp: string) => {
       latestBlock
     );
 
+    console.log("-$_$-$-$    3 - fast");
+
     const transactionsSlp = getHistoricalSlpTransactions(
       address,
       addressSlp,
       latestBlock
     );
 
+    console.log("-$_$-$-$    4 - fast");
+
     const [bchHistory, slpHistory] = await Promise.all([
       transactionsBCH,
       transactionsSlp
     ]);
+
+    console.log("-$_$-$-$    5 - medium");
+    console.log(bchHistory.length);
 
     const formattedTransactionsBCH: Transaction[] = bchHistory
       .map(tx => {
@@ -98,10 +122,13 @@ const updateTransactions = (address: string, addressSlp: string) => {
         let toAddress = toAddresses.length === 1 ? toAddresses[0] : null;
 
         // Detect if it's from this wallet
-        let fromUser = fromAddresses.reduce((acc, curr) => {
-          if (acc) return acc;
-          return [address, addressSlp].includes(curr);
-        }, false);
+        // const fromUser = fromAddresses.reduce((acc, curr) => {
+        //   if (acc) return acc;
+        //   return [address, addressSlp].includes(curr);
+        // }, false);
+
+        const fromUser =
+          fromAddresses.includes(address) || fromAddresses.includes(addressSlp);
 
         // if from us, search for an external address
         if (fromUser) {
@@ -118,26 +145,22 @@ const updateTransactions = (address: string, addressSlp: string) => {
             : toAddresses.includes(addressSlp) && addressSlp;
         }
 
-        const valueAddresses = fromUser
-          ? toAddresses.filter(
-              target => ![address, addressSlp].includes(target)
-            )
-          : toAddresses.filter(target =>
-              [address, addressSlp].includes(target)
-            );
+        const valueAddresses = toAddresses.filter(target => {
+          return fromUser
+            ? ![address, addressSlp].includes(target)
+            : [address, addressSlp].includes(target);
+        });
 
         // Determine value
         let value = 0;
         if (toAddress && fromAddress !== toAddress) {
-          value = tx.out.reduce((accumulator, currentValue) => {
+          value = tx.out.reduce((accumulator, currentTx) => {
             if (
-              currentValue.e &&
-              currentValue.e.v &&
-              valueAddresses.includes(
-                SLP.Address.toCashAddress(currentValue.e.a)
-              )
+              currentTx.e &&
+              currentTx.e.v &&
+              valueAddresses.includes(SLP.Address.toCashAddress(currentTx.e.a))
             ) {
-              accumulator += currentValue.e.v;
+              accumulator += currentTx.e.v;
             }
             return accumulator;
           }, 0);
@@ -155,157 +178,326 @@ const updateTransactions = (address: string, addressSlp: string) => {
           time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
           block,
           status: "confirmed",
-          networkId: "mainnet" // Todo - Support testnet from settings
+          networkId: "mainnet"
         };
       })
       .filter(Boolean);
 
-    const formattedTransactionsSLP: Transaction[] = slpHistory
-      .map(tx => {
-        const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
-        const hash = tx.tx.h;
+    console.log("-$_$-$-$    5.5 - SLOW");
+    console.log(slpHistory.length);
 
-        // Unconfirmed and already parsed
-        if (block === 0 && allTxIds.has(hash)) {
-          return null;
-        }
+    console.time("slp");
 
-        const { slp } = tx;
-        const inputs = tx.in;
+    const slpHistoryChunks = _.chunk(slpHistory, 2);
+    const formattedTransactionsSLP = [];
 
-        const { outputs, tokenIdHex, transactionType, decimals } = slp.detail;
+    for (let historyChunk of slpHistoryChunks) {
+      const formattedChunk = historyChunk
+        .map(tx => {
+          const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
+          const hash = tx.tx.h;
 
-        // All from addresses in cashaddr format
-        const fromAddresses = inputs
-          .filter(input => input.e && input.e.a)
-          .map(input => {
-            const addr = SLP.Address.toCashAddress(input.e.a);
-            return addr;
-          });
-
-        // All to addresses in cashaddr format
-        const toAddressesSLP = outputs
-          .filter(output => output.address)
-          .map(output => {
-            const addr = SLP.Address.toCashAddress(output.address);
-            return addr;
-          });
-
-        const toAddressesBCHAll = tx.out
-          .filter(output => output.e && output.e.a)
-          .map(output => SLP.Address.toCashAddress(output.e.a));
-
-        const toAddressesBCH = [...new Set(toAddressesBCHAll)];
-
-        const toAddresses = [...toAddressesSLP, ...toAddressesBCH];
-
-        // Detect if it's from this wallet
-        let fromUser = fromAddresses.reduce((acc, curr) => {
-          if (acc) return acc;
-          return [address, addressSlp].includes(curr);
-        }, false);
-
-        let fromAddress = fromAddresses.length === 1 ? fromAddresses[0] : null;
-
-        // If sending SLP, show from SLP address over the BCH address
-        if (!fromAddress) {
-          if (fromAddresses.includes(addressSlp)) {
-            fromAddress = addressSlp;
-          } else if (fromAddresses.includes(address)) {
-            fromAddress = address;
+          // Unconfirmed and already parsed
+          if (block === 0 && allTxIds.has(hash)) {
+            return null;
           }
-        }
 
-        let toAddress = null;
+          const { slp } = tx;
+          const inputs = tx.in;
 
-        // if from us, search for an external address
-        if (fromUser) {
-          toAddress = toAddresses.reduce((acc, curr) => {
+          const { outputs, tokenIdHex, transactionType, decimals } = slp.detail;
+
+          // All from addresses in cashaddr format
+          const fromAddresses = inputs
+            .filter(input => input.e && input.e.a)
+            .map(input => {
+              const addr = SLP.Address.toCashAddress(input.e.a);
+              return addr;
+            });
+
+          // All to addresses in cashaddr format
+          const toAddressesSLP = outputs
+            .filter(output => output.address)
+            .map(output => {
+              const addr = SLP.Address.toCashAddress(output.address);
+              return addr;
+            });
+
+          const toAddressesBCHAll = tx.out
+            .filter(output => output.e && output.e.a)
+            .map(output => SLP.Address.toCashAddress(output.e.a));
+
+          const toAddressesBCH = [...new Set(toAddressesBCHAll)];
+
+          const toAddresses = [...toAddressesSLP, ...toAddressesBCH];
+
+          // Detect if it's from this wallet
+          let fromUser = fromAddresses.reduce((acc, curr) => {
             if (acc) return acc;
-            return [address, addressSlp].includes(curr) ? null : curr;
-          }, null);
-        } else {
-          // else search for one of our addresses
-          toAddress = toAddresses.includes(addressSlp)
-            ? addressSlp
-            : toAddresses.includes(address) && address;
-        }
+            return [address, addressSlp].includes(curr);
+          }, false);
 
-        // Else from and to us?
-        if (fromUser && !toAddress) {
-          // Change to false so these appear as received
-          fromUser = false;
-          toAddress = toAddresses.includes(addressSlp)
-            ? addressSlp
-            : toAddresses.includes(address) && address;
-        }
+          let fromAddress =
+            fromAddresses.length === 1 ? fromAddresses[0] : null;
 
-        // Determine SLP value
-        let value = new BigNumber(0);
-        if (toAddress && fromAddress !== toAddress) {
-          value = outputs.reduce((accumulator, currentValue) => {
-            if (currentValue.address && currentValue.amount) {
-              const outputAddress = SLP.Address.toCashAddress(
-                currentValue.address
-              );
-              if (outputAddress === toAddress) {
-                accumulator = accumulator.plus(
-                  new BigNumber(currentValue.amount)
+          // If sending SLP, show from SLP address over the BCH address
+          if (!fromAddress) {
+            if (fromAddresses.includes(addressSlp)) {
+              fromAddress = addressSlp;
+            } else if (fromAddresses.includes(address)) {
+              fromAddress = address;
+            }
+          }
+
+          let toAddress = null;
+
+          // if from us, search for an external address
+          if (fromUser) {
+            toAddress = toAddresses.reduce((acc, curr) => {
+              if (acc) return acc;
+              return [address, addressSlp].includes(curr) ? null : curr;
+            }, null);
+          } else {
+            // else search for one of our addresses
+            toAddress = toAddresses.includes(addressSlp)
+              ? addressSlp
+              : toAddresses.includes(address) && address;
+          }
+
+          // Else from and to us?
+          if (fromUser && !toAddress) {
+            // Change to false so these appear as received
+            fromUser = false;
+            toAddress = toAddresses.includes(addressSlp)
+              ? addressSlp
+              : toAddresses.includes(address) && address;
+          }
+
+          // Determine SLP value
+          let value = new BigNumber(0);
+          if (toAddress && fromAddress !== toAddress) {
+            value = outputs.reduce((accumulator, currentValue) => {
+              if (currentValue.address && currentValue.amount) {
+                const outputAddress = SLP.Address.toCashAddress(
+                  currentValue.address
                 );
+                if (outputAddress === toAddress) {
+                  accumulator = accumulator.plus(
+                    new BigNumber(currentValue.amount)
+                  );
+                }
               }
-            }
-            return accumulator;
-          }, new BigNumber(0));
-        }
+              return accumulator;
+            }, new BigNumber(0));
+          }
 
-        const valueAddresses = fromUser
-          ? toAddresses.filter(
-              target => ![address, addressSlp].includes(target)
-            )
-          : toAddresses.filter(target =>
-              [address, addressSlp].includes(target)
-            );
+          const valueAddresses = fromUser
+            ? toAddresses.filter(
+                target => ![address, addressSlp].includes(target)
+              )
+            : toAddresses.filter(target =>
+                [address, addressSlp].includes(target)
+              );
 
-        // Determine BCH value
-        let bchValue = 0;
-        if (toAddress && fromAddress !== toAddress) {
-          bchValue = tx.out.reduce((accumulator, currentValue) => {
-            if (
-              currentValue.e &&
-              currentValue.e.v &&
-              valueAddresses.includes(
-                SLP.Address.toCashAddress(currentValue.e.a)
-              ) &&
-              currentValue.e.v !== 546
-            ) {
-              accumulator += currentValue.e.v;
-            }
-            return accumulator;
-          }, 0);
-        }
+          // Determine BCH value
+          let bchValue = 0;
+          if (toAddress && fromAddress !== toAddress) {
+            bchValue = tx.out.reduce((accumulator, currentTx) => {
+              if (
+                currentTx.e &&
+                currentTx.e.v &&
+                valueAddresses.includes(
+                  SLP.Address.toCashAddress(currentTx.e.a)
+                ) &&
+                currentTx.e.v !== 546
+              ) {
+                accumulator += currentTx.e.v;
+              }
+              return accumulator;
+            }, 0);
+          }
 
-        return {
-          hash,
-          txParams: {
-            from: fromAddress,
-            to: toAddress,
-            fromAddresses,
-            toAddresses,
-            valueBch: bchValue,
-            transactionType,
-            sendTokenData: {
-              tokenProtocol: "slp",
-              tokenId: tokenIdHex,
-              valueToken: value.toFixed(decimals)
-            }
-          },
-          time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
-          block,
-          status: "confirmed",
-          network: "mainnet"
-        };
-      })
-      .filter(Boolean);
+          return {
+            hash,
+            txParams: {
+              from: fromAddress,
+              to: toAddress,
+              fromAddresses,
+              toAddresses,
+              valueBch: bchValue,
+              transactionType,
+              sendTokenData: {
+                tokenProtocol: "slp",
+                tokenId: tokenIdHex,
+                valueToken: value.toFixed(decimals)
+              }
+            },
+            time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
+            block,
+            status: "confirmed",
+            network: "mainnet"
+          };
+        })
+        .filter(Boolean);
+
+      console.log("render release?");
+      formattedTransactionsSLP.push(...formattedChunk);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      console.log("render done?");
+    }
+
+    console.log("done?");
+    console.log(formattedTransactionsSLP.length);
+
+    // const formattedTransactionsSLP: Transaction[] = slpHistory
+    //   .map(tx => {
+    //     const block = tx.blk && tx.blk.i ? tx.blk.i : 0;
+    //     const hash = tx.tx.h;
+
+    //     // Unconfirmed and already parsed
+    //     if (block === 0 && allTxIds.has(hash)) {
+    //       return null;
+    //     }
+
+    //     const { slp } = tx;
+    //     const inputs = tx.in;
+
+    //     const { outputs, tokenIdHex, transactionType, decimals } = slp.detail;
+
+    //     // All from addresses in cashaddr format
+    //     const fromAddresses = inputs
+    //       .filter(input => input.e && input.e.a)
+    //       .map(input => {
+    //         const addr = SLP.Address.toCashAddress(input.e.a);
+    //         return addr;
+    //       });
+
+    //     // All to addresses in cashaddr format
+    //     const toAddressesSLP = outputs
+    //       .filter(output => output.address)
+    //       .map(output => {
+    //         const addr = SLP.Address.toCashAddress(output.address);
+    //         return addr;
+    //       });
+
+    //     const toAddressesBCHAll = tx.out
+    //       .filter(output => output.e && output.e.a)
+    //       .map(output => SLP.Address.toCashAddress(output.e.a));
+
+    //     const toAddressesBCH = [...new Set(toAddressesBCHAll)];
+
+    //     const toAddresses = [...toAddressesSLP, ...toAddressesBCH];
+
+    //     // Detect if it's from this wallet
+    //     let fromUser = fromAddresses.reduce((acc, curr) => {
+    //       if (acc) return acc;
+    //       return [address, addressSlp].includes(curr);
+    //     }, false);
+
+    //     let fromAddress = fromAddresses.length === 1 ? fromAddresses[0] : null;
+
+    //     // If sending SLP, show from SLP address over the BCH address
+    //     if (!fromAddress) {
+    //       if (fromAddresses.includes(addressSlp)) {
+    //         fromAddress = addressSlp;
+    //       } else if (fromAddresses.includes(address)) {
+    //         fromAddress = address;
+    //       }
+    //     }
+
+    //     let toAddress = null;
+
+    //     // if from us, search for an external address
+    //     if (fromUser) {
+    //       toAddress = toAddresses.reduce((acc, curr) => {
+    //         if (acc) return acc;
+    //         return [address, addressSlp].includes(curr) ? null : curr;
+    //       }, null);
+    //     } else {
+    //       // else search for one of our addresses
+    //       toAddress = toAddresses.includes(addressSlp)
+    //         ? addressSlp
+    //         : toAddresses.includes(address) && address;
+    //     }
+
+    //     // Else from and to us?
+    //     if (fromUser && !toAddress) {
+    //       // Change to false so these appear as received
+    //       fromUser = false;
+    //       toAddress = toAddresses.includes(addressSlp)
+    //         ? addressSlp
+    //         : toAddresses.includes(address) && address;
+    //     }
+
+    //     // Determine SLP value
+    //     let value = new BigNumber(0);
+    //     if (toAddress && fromAddress !== toAddress) {
+    //       value = outputs.reduce((accumulator, currentValue) => {
+    //         if (currentValue.address && currentValue.amount) {
+    //           const outputAddress = SLP.Address.toCashAddress(
+    //             currentValue.address
+    //           );
+    //           if (outputAddress === toAddress) {
+    //             accumulator = accumulator.plus(
+    //               new BigNumber(currentValue.amount)
+    //             );
+    //           }
+    //         }
+    //         return accumulator;
+    //       }, new BigNumber(0));
+    //     }
+
+    //     const valueAddresses = fromUser
+    //       ? toAddresses.filter(
+    //           target => ![address, addressSlp].includes(target)
+    //         )
+    //       : toAddresses.filter(target =>
+    //           [address, addressSlp].includes(target)
+    //         );
+
+    //     // Determine BCH value
+    //     let bchValue = 0;
+    //     if (toAddress && fromAddress !== toAddress) {
+    //       bchValue = tx.out.reduce((accumulator, currentTx) => {
+    //         if (
+    //           currentTx.e &&
+    //           currentTx.e.v &&
+    //           valueAddresses.includes(
+    //             SLP.Address.toCashAddress(currentTx.e.a)
+    //           ) &&
+    //           currentTx.e.v !== 546
+    //         ) {
+    //           accumulator += currentTx.e.v;
+    //         }
+    //         return accumulator;
+    //       }, 0);
+    //     }
+
+    //     return {
+    //       hash,
+    //       txParams: {
+    //         from: fromAddress,
+    //         to: toAddress,
+    //         fromAddresses,
+    //         toAddresses,
+    //         valueBch: bchValue,
+    //         transactionType,
+    //         sendTokenData: {
+    //           tokenProtocol: "slp",
+    //           tokenId: tokenIdHex,
+    //           valueToken: value.toFixed(decimals)
+    //         }
+    //       },
+    //       time: tx.blk && tx.blk.t ? tx.blk.t * 1000 : new Date().getTime(),
+    //       block,
+    //       status: "confirmed",
+    //       network: "mainnet"
+    //     };
+    //   })
+    //   .filter(Boolean);
+
+    console.log("-$_$-$-$    6 - SLOW - DONE");
+    console.timeEnd("slp");
 
     const formattedTransactionsNew = [
       ...formattedTransactionsBCH,

--- a/data/transactions/reducer.js
+++ b/data/transactions/reducer.js
@@ -10,14 +10,13 @@ import {
 export type Transaction = {
   hash: string,
   txParams: {
-    from: string,
+    from: ?string,
     to: string,
     transactionType?: "SEND" | "MINT",
     fromAddresses: string[],
     toAddresses: string[],
-    value: string,
-    valueBch: string,
-    miningFee: string,
+    value?: string,
+    valueBch: number,
     sendTokenData?: {
       tokenProtocol: "slp",
       tokenId: string,
@@ -51,6 +50,8 @@ const addTransactions = (
 ) => {
   const { transactions, address } = payload;
 
+  console.log("ad success");
+
   const transactionsById = transactions.reduce((acc, tx) => {
     return { ...acc, [tx.hash]: tx };
   }, {});
@@ -59,6 +60,8 @@ const addTransactions = (
 
   const existingAccountTxs = state.byAccount[address] || [];
   const nextAccountTxs = new Set([...existingAccountTxs, ...txIds]);
+
+  console.log("ad finishing");
 
   return {
     ...state,

--- a/data/transactions/reducer.js
+++ b/data/transactions/reducer.js
@@ -50,8 +50,6 @@ const addTransactions = (
 ) => {
   const { transactions, address } = payload;
 
-  console.log("ad success");
-
   const transactionsById = transactions.reduce((acc, tx) => {
     return { ...acc, [tx.hash]: tx };
   }, {});
@@ -60,8 +58,6 @@ const addTransactions = (
 
   const existingAccountTxs = state.byAccount[address] || [];
   const nextAccountTxs = new Set([...existingAccountTxs, ...txIds]);
-
-  console.log("ad finishing");
 
   return {
     ...state,

--- a/data/transactions/selectors.js
+++ b/data/transactions/selectors.js
@@ -7,6 +7,13 @@ import { type FullState } from "../store";
 
 const transactionsSelector = (state: FullState) => state.transactions;
 
+const isUpdatingTransactionsSelector = createSelector(
+  transactionsSelector,
+  transactions => {
+    return transactions.updating;
+  }
+);
+
 // const transactionsByAccountSelector = (
 //   state: FullState,
 //   { address, tokenId }: { address: ?string, tokenId?: ?string }
@@ -32,4 +39,4 @@ const transactionsSelector = (state: FullState) => state.transactions;
 //   return _.sortBy(transactions, ["time"]).reverse();
 // };
 
-export { transactionsSelector };
+export { transactionsSelector, isUpdatingTransactionsSelector };

--- a/screens/WalletDetailScreen.js
+++ b/screens/WalletDetailScreen.js
@@ -29,6 +29,7 @@ import {
 } from "../data/selectors";
 import { spotPricesSelector, currencySelector } from "../data/prices/selectors";
 import { tokensByIdSelector } from "../data/tokens/selectors";
+import { isUpdatingTransactionsSelector } from "../data/transactions/selectors";
 
 import { type Transaction } from "../data/transactions/reducer";
 import { type TokenData } from "../data/tokens/reducer";
@@ -81,7 +82,8 @@ type Props = {
   navigation: { navigate: Function, state: { params: any } },
   tokensById: { [tokenId: string]: TokenData },
   updateTransactions: Function,
-  transactions: Transaction[]
+  transactions: Transaction[],
+  isUpdatingTransactions: boolean
 };
 
 const WalletDetailScreen = ({
@@ -93,7 +95,8 @@ const WalletDetailScreen = ({
   spotPrices,
   fiatCurrency,
   transactions,
-  updateTransactions
+  updateTransactions,
+  isUpdatingTransactions
 }: Props) => {
   const { tokenId } = navigation.state.params;
   const token = tokensById[tokenId];
@@ -284,6 +287,18 @@ const WalletDetailScreen = ({
               />
             );
           })}
+          {isUpdatingTransactions && (
+            <>
+              <Spacer small />
+              <T size="small" type="muted" center>
+                Transaction history updating...
+              </T>
+              <T size="xsmall" type="muted2" center>
+                This may take a few minutes.
+              </T>
+              <Spacer small />
+            </>
+          )}
           <ExplorerRow>
             <Spacer small />
             <T
@@ -312,6 +327,8 @@ const mapStateToProps = (state, props) => {
 
   const transactionsAll = transactionsActiveAccountSelector(state);
 
+  const isUpdatingTransactions = isUpdatingTransactionsSelector(state);
+
   const transactions = transactionsAll
     .filter(tx => {
       const txTokenId =
@@ -330,7 +347,8 @@ const mapStateToProps = (state, props) => {
     tokensById,
     transactions,
     spotPrices,
-    fiatCurrency
+    fiatCurrency,
+    isUpdatingTransactions
   };
 };
 

--- a/utils/balance-utils.js
+++ b/utils/balance-utils.js
@@ -133,7 +133,7 @@ const getHistoricalSlpTransactions = async (
         "slp.detail": 1,
         blk: 1
       },
-      limit: 150
+      limit: 500
     }
   };
 

--- a/utils/balance-utils.js
+++ b/utils/balance-utils.js
@@ -65,9 +65,7 @@ const getHistoricalBchTransactions = async (
   };
 
   try {
-    console.log("BIT DB CALL");
     const result = await SLP.BitDB.get(query);
-    console.log("BIT DB CALL DONE");
 
     // combine confirmed and unconfirmed
     // errors = slpdb, error = REST rate limit
@@ -79,7 +77,6 @@ const getHistoricalBchTransactions = async (
     if (result.u) {
       transactions = [...transactions, ...result.u];
     }
-    // result.errors || result.error ? [] : [...result.c, ...result.u];
 
     return transactions;
   } catch (e) {
@@ -142,12 +139,9 @@ const getHistoricalSlpTransactions = async (
 
   let transactions = [];
   try {
-    console.log("LSP DB CALL");
     const result = await SLP.SLPDB.get(query);
-    console.log("SLP DB CALL DONE");
     // combine confirmed and unconfirmed
     // errors = slpdb, error = REST rate limit
-    // let transactions = [];
 
     if (result.c) {
       transactions = [...transactions, ...result.c];

--- a/utils/balance-utils.js
+++ b/utils/balance-utils.js
@@ -65,12 +65,21 @@ const getHistoricalBchTransactions = async (
   };
 
   try {
+    console.log("BIT DB CALL");
     const result = await SLP.BitDB.get(query);
+    console.log("BIT DB CALL DONE");
 
     // combine confirmed and unconfirmed
     // errors = slpdb, error = REST rate limit
-    const transactions =
-      result.errors || result.error ? [] : [...result.c, ...result.u];
+    let transactions = [];
+
+    if (result.c) {
+      transactions = [...transactions, ...result.c];
+    }
+    if (result.u) {
+      transactions = [...transactions, ...result.u];
+    }
+    // result.errors || result.error ? [] : [...result.c, ...result.u];
 
     return transactions;
   } catch (e) {
@@ -127,14 +136,25 @@ const getHistoricalSlpTransactions = async (
         "slp.detail": 1,
         blk: 1
       },
-      limit: 500
+      limit: 150
     }
   };
 
   let transactions = [];
   try {
+    console.log("LSP DB CALL");
     const result = await SLP.SLPDB.get(query);
-    transactions = [...result.c, ...result.u];
+    console.log("SLP DB CALL DONE");
+    // combine confirmed and unconfirmed
+    // errors = slpdb, error = REST rate limit
+    // let transactions = [];
+
+    if (result.c) {
+      transactions = [...transactions, ...result.c];
+    }
+    if (result.u) {
+      transactions = [...transactions, ...result.u];
+    }
   } catch (e) {
     console.warn("Error while fetching from slpdb");
     console.warn(e);


### PR DESCRIPTION
Fixes an issue where parsing the transaction history on wallets with 100+ transactions would cause the UI to hang for upwards of 2 minutes on initial load.

This resolves that by passing work to the UI frame after each item is parsed, and providing a visual indicator to the user that the history is updating.

fixes #211 