### PR TITLE
History sync improvements slower phones

### DIFF
--- a/data/transactions/actions.js
+++ b/data/transactions/actions.js
@@ -39,6 +39,15 @@ const updateTransactions = (address: string, addressSlp: string) => {
     if (!address || !addressSlp) return;
 
     const currentState = getState();
+    const isUpdating = currentState.transactions.updating;
+    const lastUpdate = currentState.transactions.lastUpdate || 0;
+
+    const now = +new Date();
+
+    // Short circuit if already processing, and it's been under 7 minutes
+    if (isUpdating && now - lastUpdate < 1000 * 60 * 7) {
+      return;
+    }
 
     dispatch(getTransactionsStart());
 
@@ -157,7 +166,7 @@ const updateTransactions = (address: string, addressSlp: string) => {
       formattedTx && formattedTransactionsBCH.push(formattedTx);
 
       // Allow the UI to render after each item computes.
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 50));
     }
 
     const formattedTransactionsSLP: Transaction[] = [];
@@ -302,7 +311,7 @@ const updateTransactions = (address: string, addressSlp: string) => {
       formattedTx && formattedTransactionsSLP.push(formattedTx);
 
       // Allow the UI to render after each item computes.
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 60));
     }
 
     const formattedTransactionsNew = [

--- a/data/transactions/reducer.js
+++ b/data/transactions/reducer.js
@@ -34,14 +34,16 @@ export type State = {
   byId: { [transactionId: string]: Transaction },
   allIds: string[],
   byAccount: { [accountId: string]: string[] },
-  updating: boolean
+  updating: boolean,
+  lastUpdate: number
 };
 
 export const initialState: State = {
   byId: {},
   allIds: [],
   byAccount: {},
-  updating: false
+  updating: false,
+  lastUpdate: +new Date()
 };
 
 const addTransactions = (
@@ -67,7 +69,8 @@ const addTransactions = (
       [address]: [...nextAccountTxs]
     },
     allIds: [...state.allIds, ...txIds],
-    updating: false
+    updating: false,
+    lastUpdate: +new Date()
   };
 };
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -128,15 +128,17 @@ const HomeScreen = ({
     };
   }, [address, addressSlp, updateUtxos]);
 
-  // Update transaction history
+  // Update transaction history initial
   useEffect(() => {
-    if (!address) return;
-
+    if (!address || !addressSlp) return;
     updateTransactions(address, addressSlp);
-    const transactionInterval = setInterval(
-      () => updateTransactions(address, addressSlp),
-      25 * 1000
-    );
+  }, [address, addressSlp, updateTransactions]);
+
+  // Update transaction history interval
+  useEffect(() => {
+    const transactionInterval = setInterval(() => {
+      updateTransactions(address, addressSlp);
+    }, 30 * 1000);
     return () => {
       clearInterval(transactionInterval);
     };
@@ -299,15 +301,10 @@ const mapStateToProps = (state, props) => {
   const address = getAddressSelector(state);
   const addressSlp = getAddressSlpSelector(state);
   const balances = balancesSelector(state, address);
-
   const tokensById = tokensByIdSelector(state);
-
   const spotPrices = spotPricesSelector(state);
-
   const seedViewed = getSeedViewedSelector(state);
-
   const initialLoadingDone = doneInitialLoadSelector(state, address);
-
   const fiatCurrency = currencySelector(state);
 
   return {
@@ -329,7 +326,4 @@ const mapDispatchToProps = {
   updateUtxos
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(HomeScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(HomeScreen);

--- a/utils/balance-utils.js
+++ b/utils/balance-utils.js
@@ -133,7 +133,7 @@ const getHistoricalSlpTransactions = async (
         "slp.detail": 1,
         blk: 1
       },
-      limit: 500
+      limit: 350
     }
   };
 


### PR DESCRIPTION
- Reduce total SLP history to 350
- Shortcut the transaction update process if still flagged as running, prevents the computations running multiple times which was causing slower phones to hang
- Increase the timeout to allow slower phones more time to process UI updates

fixes #212 