### PR TITLE
SLP Blacklist -> SLP Favorites

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "com.badgermobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9000020
-        versionName "1.12.0"
+        versionCode 9000021
+        versionName "1.12.1"
         missingDimensionStrategy 'react-native-camera', 'general'
     }
     splits {

--- a/data/settings/actions.ts
+++ b/data/settings/actions.ts
@@ -1,16 +1,16 @@
 import {
-  REMOVE_TOKEN_FROM_BLACKLIST,
-  ADD_TOKEN_TO_BLACKLIST
+  REMOVE_TOKEN_FROM_FAVORITES,
+  ADD_TOKEN_TO_FAVORITES
 } from "./constants";
 
-const addTokenToBlacklist = (tokenId: string) => ({
-  type: ADD_TOKEN_TO_BLACKLIST,
+const addTokenToFavorites = (tokenId: string) => ({
+  type: ADD_TOKEN_TO_FAVORITES,
   payload: tokenId
 });
 
-const removeTokenFromBlacklist = (tokenId: string) => ({
-  type: REMOVE_TOKEN_FROM_BLACKLIST,
+const removeTokenFromFavorites = (tokenId: string) => ({
+  type: REMOVE_TOKEN_FROM_FAVORITES,
   payload: tokenId
 });
 
-export { addTokenToBlacklist, removeTokenFromBlacklist };
+export { addTokenToFavorites, removeTokenFromFavorites };

--- a/data/settings/constants.ts
+++ b/data/settings/constants.ts
@@ -1,3 +1,3 @@
-export const ADD_TOKEN_TO_BLACKLIST = "badger::accounts:ADD_TOKEN_TO_BLACKLIST";
-export const REMOVE_TOKEN_FROM_BLACKLIST =
-  "badger::accounts:REMOVE_TOKEN_FROM_BLACKLIST";
+export const ADD_TOKEN_TO_FAVORITES = "badger::accounts:ADD_TOKEN_TO_FAVORITES";
+export const REMOVE_TOKEN_FROM_FAVORITES =
+  "badger::accounts:REMOVE_TOKEN_FROM_FAVORITES";

--- a/data/settings/reducer.ts
+++ b/data/settings/reducer.ts
@@ -1,6 +1,6 @@
 import {
-  REMOVE_TOKEN_FROM_BLACKLIST,
-  ADD_TOKEN_TO_BLACKLIST
+  REMOVE_TOKEN_FROM_FAVORITES,
+  ADD_TOKEN_TO_FAVORITES
 } from "./constants";
 
 type Action = {
@@ -9,45 +9,49 @@ type Action = {
 };
 
 export interface SettingsState {
-  tokenBlacklist: string[];
+  tokenFavorites: string[] | undefined;
 }
 export const initialState: SettingsState = {
-  tokenBlacklist: []
+  tokenFavorites: []
 };
 
-const addTokenToBlacklist = (
+const addTokenToFavorites = (
   state: SettingsState,
   tokenId: string
 ): SettingsState => {
-  const { tokenBlacklist } = state;
-  const updatedBlacklist = [...new Set([...tokenBlacklist, tokenId])];
+  const { tokenFavorites } = state;
+  const updatedFavorites = tokenFavorites
+    ? [...new Set([...tokenFavorites, tokenId])]
+    : [tokenId];
 
   return {
     ...state,
-    tokenBlacklist: updatedBlacklist
+    tokenFavorites: updatedFavorites
   };
 };
 
-const removeTokenFromBlacklist = (
+const removeTokenFromFavorites = (
   state: SettingsState,
   tokenId: string
 ): SettingsState => {
-  const { tokenBlacklist } = state;
-  const updatedBlacklist = tokenBlacklist.filter(x => x !== tokenId);
+  const { tokenFavorites } = state;
+  const updatedFavorites = tokenFavorites
+    ? tokenFavorites.filter(x => x !== tokenId)
+    : [];
 
   return {
     ...state,
-    tokenBlacklist: updatedBlacklist
+    tokenFavorites: updatedFavorites
   };
 };
 
 const settings = (state = initialState, action: Action): SettingsState => {
   switch (action.type) {
-    case ADD_TOKEN_TO_BLACKLIST:
-      return addTokenToBlacklist(state, action.payload);
+    case ADD_TOKEN_TO_FAVORITES:
+      return addTokenToFavorites(state, action.payload);
 
-    case REMOVE_TOKEN_FROM_BLACKLIST:
-      return removeTokenFromBlacklist(state, action.payload);
+    case REMOVE_TOKEN_FROM_FAVORITES:
+      return removeTokenFromFavorites(state, action.payload);
 
     default:
       return state;

--- a/data/settings/selectors.ts
+++ b/data/settings/selectors.ts
@@ -3,8 +3,8 @@ import { FullState } from "../store";
 
 const settingsSelector = (state: FullState) => state.settings;
 
-const tokenBlacklistSelector = createSelector(settingsSelector, settings => {
-  return settings.tokenBlacklist;
+const tokenFavoritesSelector = createSelector(settingsSelector, settings => {
+  return settings.tokenFavorites;
 });
 
-export { settingsSelector, tokenBlacklistSelector };
+export { settingsSelector, tokenFavoritesSelector };

--- a/ios/badgerMobile.xcodeproj/project.pbxproj
+++ b/ios/badgerMobile.xcodeproj/project.pbxproj
@@ -625,7 +625,7 @@
 				DEVELOPMENT_TEAM = 299HJ3G3BP;
 				INFOPLIST_FILE = badgerMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.14.1;
+				MARKETING_VERSION = 0.14.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -647,7 +647,7 @@
 				DEVELOPMENT_TEAM = 299HJ3G3BP;
 				INFOPLIST_FILE = badgerMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.14.1;
+				MARKETING_VERSION = 0.14.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badgerMobile",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "license": "MIT",
   "homepage": "https://badger.bitcoin.com",
   "repository": {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -145,8 +145,6 @@ const HomeScreen = ({
   updateUtxos,
   tokenFavorites
 }: Props) => {
-  const [isShowingFavorites, setIsShowingFavorites] = useState(false);
-
   useEffect(() => {
     // Update UTXOs on an interval
     if (!address) return;

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -237,14 +237,17 @@ const HomeScreen = ({
     return tokensSorted;
   }, [balances.slpTokens, tokensById]);
 
-  const favoriteTokensSection: WalletSection = useMemo(() => {
+  const favoriteTokensSection: WalletSection | null = useMemo(() => {
     const filteredTokens = tokenData.filter(
       data => tokenFavorites && tokenFavorites.includes(data.tokenId)
     );
-    return {
-      title: "SLP Tokens - Favorites",
-      data: filteredTokens
-    };
+
+    return filteredTokens.length
+      ? {
+          title: "SLP Tokens - Favorites",
+          data: filteredTokens
+        }
+      : null;
   }, [tokenData, tokenFavorites]);
 
   const tokensSection: WalletSection = useMemo(() => {
@@ -271,8 +274,8 @@ const HomeScreen = ({
     };
 
     return [sectionBCH, favoriteTokensSection, tokensSection].filter(
-      target => target && target.data.length
-    );
+      Boolean
+    ) as WalletSection[];
   }, [
     BCHFiatDisplay,
     balances.satoshisAvailable,

--- a/screens/MenuScreen.tsx
+++ b/screens/MenuScreen.tsx
@@ -176,7 +176,7 @@ const MenuScreen = ({ navigation, seedViewed, fiatCurrency }: Props) => {
         <Spacer small />
         <T center size="small" type="muted2">
           {/* Version {packageJson.version} */}
-          Version 0.14.1
+          Version 0.14.2
         </T>
         <Spacer small />
       </StyledScrollView>

--- a/screens/MenuScreen.tsx
+++ b/screens/MenuScreen.tsx
@@ -14,7 +14,7 @@ import {
 
 import { getSeedViewedSelector } from "../data/accounts/selectors";
 
-import { currencySymbolMap, CurrencyCode } from "../utils/currency-utils";
+import { currencySymbolMap } from "../utils/currency-utils";
 import { currencySelector } from "../data/prices/selectors";
 
 import { T, Spacer } from "../atoms";

--- a/screens/WalletDetailScreen.tsx
+++ b/screens/WalletDetailScreen.tsx
@@ -30,13 +30,13 @@ import {
 import { spotPricesSelector, currencySelector } from "../data/prices/selectors";
 import { tokensByIdSelector } from "../data/tokens/selectors";
 import { isUpdatingTransactionsSelector } from "../data/transactions/selectors";
-import { tokenBlacklistSelector } from "../data/settings/selectors";
+import { tokenFavoritesSelector } from "../data/settings/selectors";
 
 import { Transaction } from "../data/transactions/reducer";
 
 import {
-  addTokenToBlacklist,
-  removeTokenFromBlacklist
+  addTokenToFavorites,
+  removeTokenFromFavorites
 } from "../data/settings/actions";
 
 import {
@@ -110,7 +110,7 @@ const mapStateToProps = (state: FullState, props: PropsFromParent) => {
   const fiatCurrency = currencySelector(state);
   const transactionsAll = transactionsActiveAccountSelector(state);
   const isUpdatingTransactions = isUpdatingTransactionsSelector(state);
-  const tokenBlacklist = tokenBlacklistSelector(state);
+  const tokenFavorites = tokenFavoritesSelector(state);
 
   const transactions = transactionsAll
     .filter(tx => {
@@ -133,11 +133,11 @@ const mapStateToProps = (state: FullState, props: PropsFromParent) => {
     spotPrices,
     fiatCurrency,
     isUpdatingTransactions,
-    tokenBlacklist
+    tokenFavorites
   };
 };
 
-const mapDispatchToProps = { addTokenToBlacklist, removeTokenFromBlacklist };
+const mapDispatchToProps = { addTokenToFavorites, removeTokenFromFavorites };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
@@ -154,9 +154,9 @@ const WalletDetailScreen = ({
   fiatCurrency,
   transactions,
   isUpdatingTransactions,
-  tokenBlacklist,
-  addTokenToBlacklist,
-  removeTokenFromBlacklist
+  tokenFavorites,
+  addTokenToFavorites,
+  removeTokenFromFavorites
 }: Props) => {
   const { tokenId } = navigation.state.params;
   const token = tokenId && tokensById[tokenId];
@@ -195,11 +195,11 @@ const WalletDetailScreen = ({
   const imageSource = useMemo(() => getTokenImage(tokenId), [tokenId]);
 
   let fiatAmount = null;
-  let isBlacklisted = false;
+  let isFavorite = false;
 
   if (tokenId) {
     fiatAmount = computeFiatAmount(amount, spotPrices, fiatCurrency, tokenId);
-    isBlacklisted = tokenBlacklist.includes(tokenId);
+    isFavorite = tokenFavorites ? tokenFavorites.includes(tokenId) : false;
   } else {
     fiatAmount = computeFiatAmount(amount, spotPrices, fiatCurrency, "bch");
   }
@@ -226,9 +226,9 @@ const WalletDetailScreen = ({
 
   const HideButton = ({ tokenId }: TokenProps) => (
     <VisibilityArea>
-      <TouchableOpacity onPress={() => addTokenToBlacklist(tokenId)}>
+      <TouchableOpacity onPress={() => addTokenToFavorites(tokenId)}>
         <T type="muted2">
-          <FontAwesome name="eye" size={24} />
+          <FontAwesome name="heart-o" size={24} />
         </T>
       </TouchableOpacity>
     </VisibilityArea>
@@ -236,9 +236,9 @@ const WalletDetailScreen = ({
 
   const ShowButton = ({ tokenId }: TokenProps) => (
     <VisibilityArea>
-      <TouchableOpacity onPress={() => removeTokenFromBlacklist(tokenId)}>
-        <T type="muted2">
-          <FontAwesome name="eye-slash" size={24} />
+      <TouchableOpacity onPress={() => removeTokenFromFavorites(tokenId)}>
+        <T type="primary">
+          <FontAwesome name="heart" size={24} />
         </T>
       </TouchableOpacity>
     </VisibilityArea>
@@ -258,8 +258,8 @@ const WalletDetailScreen = ({
       >
         <View>
           <Spacer small />
-          {tokenId && isBlacklisted && <ShowButton tokenId={tokenId} />}
-          {tokenId && !isBlacklisted && <HideButton tokenId={tokenId} />}
+          {tokenId && isFavorite && <ShowButton tokenId={tokenId} />}
+          {tokenId && !isFavorite && <HideButton tokenId={tokenId} />}
 
           <Spacer small />
           <H1 center>{name}</H1>


### PR DESCRIPTION
# Summary

During testing of the blacklist, removing a bunch of spam tokens becomes very tedious, and if/when spammed with more tokens the process needs to be repeated again.  As such, I think a favorites paradigm solves this solution better until a more robust solution can be built.  
Favorites are also a more common UI element, so seeing a `heart` vs an `eye` is more clear to the standard user.  

## Changes

* Renaming blacklist to favorites throughout
* Update icon to a heart / heart-outline
* Additional error handling, managed to get the state to break during testing upgrading old accounts
* Removing second list from home screen, if the favorites are at the top, the additional list/toggle adds unnecessary complexity
* Rename `SLP Token Vault` to `SLP Tokens` and `SLP Tokens - Favorites`