### PR TITLE
Using new REST endpoint for SLPDB data

### DIFF
--- a/api/rest.bitcoin.ts
+++ b/api/rest.bitcoin.ts
@@ -4,6 +4,7 @@
 const API = `https://rest.bitcoin.com/v2`;
 
 const getBlockCountURL = `${API}/blockchain/getBlockCount`;
+const getSlpTransactionsURL = `${API}/slp/transactionHistoryAllTokens`;
 
 const getCurrentBlockheight = async () => {
   try {
@@ -16,4 +17,27 @@ const getCurrentBlockheight = async () => {
   }
 };
 
-export { getCurrentBlockheight };
+const getSlpTransactions = async (
+  address: string,
+  addressSlp: string,
+  latestBlock = 0
+) => {
+  const addresses = [address, addressSlp];
+  const req = await fetch(getSlpTransactionsURL, {
+    method: "post",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      addresses,
+      fromBlock: latestBlock
+    })
+  });
+
+  const resp = await req.json();
+
+  return resp.txs;
+};
+
+export { getCurrentBlockheight, getSlpTransactions };


### PR DESCRIPTION
* No longer directly call slpdb for SLP token transaction information
* Call new rest endpoint, which communicates to SLPDB with a specialized query

improves #223 